### PR TITLE
Use minimal hosting with certificate-authenticated KiteClient

### DIFF
--- a/KitePlatformManager/Configuration/KitePlatformOptions.cs
+++ b/KitePlatformManager/Configuration/KitePlatformOptions.cs
@@ -1,0 +1,9 @@
+namespace KitePlatformManager.Configuration;
+
+public class KitePlatformOptions
+{
+    public string BaseUrl { get; set; } = string.Empty;
+    public int Port { get; set; }
+    public string CertificatePath { get; set; } = string.Empty;
+    public string CertificatePassword { get; set; } = string.Empty;
+}

--- a/KitePlatformManager/Services/KiteClient.cs
+++ b/KitePlatformManager/Services/KiteClient.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace KitePlatformManager.Services;
+
+public class KiteClient
+{
+    private readonly HttpClient _httpClient;
+
+    public KiteClient(IHttpClientFactory factory)
+    {
+        _httpClient = factory.CreateClient("Kite");
+    }
+
+    public async IAsyncEnumerable<JsonElement> GetSubscriptionsAsync(string? lifeCycle = null, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var url = "subscriptions";
+        if (!string.IsNullOrWhiteSpace(lifeCycle))
+        {
+            url += $"?lifeCycleStatus={Uri.EscapeDataString(lifeCycle)}";
+        }
+
+        using var response = await _httpClient.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var doc = await response.Content.ReadFromJsonAsync<JsonDocument>(cancellationToken: cancellationToken);
+        if (doc != null && doc.RootElement.TryGetProperty("subscriptions", out var subs))
+        {
+            foreach (var sub in subs.EnumerateArray())
+            {
+                yield return sub;
+            }
+        }
+    }
+
+    public async Task ModifyLifecycleAsync(string icc, string targetStatus, CancellationToken cancellationToken = default)
+    {
+        var payload = JsonSerializer.Serialize(new { lifeCycleStatus = targetStatus });
+        using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PutAsync($"subscriptions/{icc}/lifecycle", content, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<string?> SendSmsAsync(string icc, string message, CancellationToken cancellationToken = default)
+    {
+        var payload = JsonSerializer.Serialize(new { message });
+        using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync($"subscriptions/{icc}/sms", content, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var doc = await response.Content.ReadFromJsonAsync<JsonDocument>(cancellationToken: cancellationToken);
+        return doc?.RootElement.GetProperty("watcherId").GetString();
+    }
+
+    public async Task<IReadOnlyList<JsonElement>> ListCommercialGroupsAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync("subscription-groups", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var doc = await response.Content.ReadFromJsonAsync<JsonDocument>(cancellationToken: cancellationToken);
+        if (doc != null && doc.RootElement.TryGetProperty("groups", out var groups))
+        {
+            return groups.EnumerateArray().ToList();
+        }
+        return Array.Empty<JsonElement>();
+    }
+}

--- a/KitePlatformManager/appsettings.json
+++ b/KitePlatformManager/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "KitePlatform": {
+    "BaseUrl": "https://api.kiteplatform.example.com",
+    "Port": 443,
+    "CertificatePath": "certs/kiteplatform.pfx",
+    "CertificatePassword": "your-cert-password"
+  }
 }


### PR DESCRIPTION
## Summary
- remove MVC controller and related services
- implement minimal hosting with certificate-based HttpClient and KiteClient wrapper
- expose `/demo/run` endpoint demonstrating subscription, lifecycle, SMS, and group calls

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ba1684308333aeec28b79cf63d73