### PR TITLE
Add SIM and subscription group routes

### DIFF
--- a/KitePlatformManager/Models/GenericModel.cs
+++ b/KitePlatformManager/Models/GenericModel.cs
@@ -1,0 +1,5 @@
+using System.Text.Json;
+
+namespace KitePlatformManager.Models;
+
+public record GenericModel(Dictionary<string, JsonElement> Fields);

--- a/KitePlatformManager/Services/KiteClient.cs
+++ b/KitePlatformManager/Services/KiteClient.cs
@@ -62,4 +62,27 @@ public class KiteClient
         }
         return Array.Empty<JsonElement>();
     }
+
+    public async Task<JsonElement?> GetSimDetailAsync(string icc, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"subscriptions/{icc}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var doc = await response.Content.ReadFromJsonAsync<JsonDocument>(cancellationToken: cancellationToken);
+        return doc?.RootElement;
+    }
+
+    public async IAsyncEnumerable<JsonElement> ListSimsAsync(int pageIndex, int pageSize, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var url = $"subscriptions?pageIndex={pageIndex}&pageSize={pageSize}";
+        using var response = await _httpClient.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var doc = await response.Content.ReadFromJsonAsync<JsonDocument>(cancellationToken: cancellationToken);
+        if (doc != null && doc.RootElement.TryGetProperty("subscriptions", out var subs))
+        {
+            foreach (var sub in subs.EnumerateArray())
+            {
+                yield return sub;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add endpoints for SIM detail, SIM list and subscription group list
- implement service methods for SIM detail and paginated SIM queries
- add generic output model and JSON field writer

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c088063c8333a7a19ed44ca2943c